### PR TITLE
Set configuration option to indicate this is a Flathub build

### DIFF
--- a/io.gitlab.osslugaru.Lugaru.json
+++ b/io.gitlab.osslugaru.Lugaru.json
@@ -20,7 +20,8 @@
       "name": "osslugaru",
       "buildsystem": "cmake-ninja",
       "config-opts": [
-        "-DSYSTEM_INSTALL=ON"
+        "-DSYSTEM_INSTALL=ON",
+        "-DLUGARU_VERSION_RELEASE='1.2-Flathub'"
       ],
       "sources": [
         {


### PR DESCRIPTION
This is not an officially maintained Flatpak by the upstream Lugaru developers, so indicate that this is a downstream build by setting the version-release string to indicate that this is a build by Flathub.


Close #3 